### PR TITLE
Add posts model, admin CRUD, public news pages and landing teaser

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,9 @@ import AktionenPage from '@/features/aktionen/AktionenPage';
 import UeberUnsPage from '@/features/ueber-uns/UeberUnsPage';
 import MitmachenPage from '@/features/mitmachen/MitmachenPage';
 import KontaktPage from '@/features/kontakt/KontaktPage';
+import NewsPage from '@/features/news/NewsPage';
+import NewsDetailPage from '@/features/news/NewsDetailPage';
+import AdminPostsPage from '@/features/admin/posts/AdminPostsPage';
 
 function ScrollToTop() {
   const { pathname } = useLocation();
@@ -35,6 +38,9 @@ export default function App() {
           <Route path="/ueber-uns" element={<UeberUnsPage />} />
           <Route path="/mitmachen" element={<MitmachenPage />} />
           <Route path="/kontakt" element={<KontaktPage />} />
+          <Route path="/news" element={<NewsPage />} />
+          <Route path="/news/:slug" element={<NewsDetailPage />} />
+          <Route path="/admin/posts" element={<AdminPostsPage />} />
         </Routes>
       </Layout>
     </BrowserRouter>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -10,6 +10,7 @@ const navLinks = [
   { href: '/ueber-uns', label: 'Über uns' },
   { href: '/mitmachen', label: 'Mitmachen' },
   { href: '/kontakt', label: 'Kontakt' },
+  { href: '/news', label: 'News' },
 ];
 
 export function Navbar() {

--- a/src/data/posts.ts
+++ b/src/data/posts.ts
@@ -1,0 +1,82 @@
+export type PostStatus = 'draft' | 'published';
+
+export type Post = {
+  id: string;
+  title: string;
+  slug: string;
+  excerpt: string;
+  content: string;
+  cover_image: string;
+  published_at: string | null;
+  author: string;
+  status: PostStatus;
+  created_at: string;
+  updated_at: string;
+};
+
+const STORAGE_KEY = 'jufo_posts';
+
+const seedPosts: Post[] = [
+  {
+    id: '1',
+    title: 'Jugendbeteiligung 2026 gestartet',
+    slug: 'jugendbeteiligung-2026-gestartet',
+    excerpt: 'Mit neuen Workshops und Mitmachformaten startet das Jugendforum in das Jahr 2026.',
+    content:
+      'Wir starten mit frischen Ideen in das neue Jahr. In mehreren Workshops sammeln wir eure Vorschläge für Grafing und setzen erste Projekte direkt gemeinsam um.',
+    cover_image:
+      'https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=80',
+    published_at: '2026-04-10T09:30:00.000Z',
+    author: 'JuFo Team',
+    status: 'published',
+    created_at: '2026-04-07T09:00:00.000Z',
+    updated_at: '2026-04-10T09:30:00.000Z',
+  },
+];
+
+const hasWindow = typeof window !== 'undefined';
+
+export function getPosts(): Post[] {
+  if (!hasWindow) return seedPosts;
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(seedPosts));
+    return seedPosts;
+  }
+
+  try {
+    return JSON.parse(raw) as Post[];
+  } catch {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(seedPosts));
+    return seedPosts;
+  }
+}
+
+function savePosts(posts: Post[]) {
+  if (!hasWindow) return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(posts));
+}
+
+export function upsertPost(post: Post) {
+  const posts = getPosts();
+  const exists = posts.find((p) => p.id === post.id);
+  const next = exists ? posts.map((p) => (p.id === post.id ? post : p)) : [post, ...posts];
+  savePosts(next);
+}
+
+export function getPostBySlug(slug: string) {
+  return getPosts().find((post) => post.slug === slug);
+}
+
+export function getLatestPublishedPosts(limit = 3) {
+  return getPosts()
+    .filter((post) => post.status === 'published' && post.published_at)
+    .sort((a, b) => new Date(b.published_at ?? 0).getTime() - new Date(a.published_at ?? 0).getTime())
+    .slice(0, limit);
+}
+
+export function getPublishedPosts() {
+  return getPosts()
+    .filter((post) => post.status === 'published' && post.published_at)
+    .sort((a, b) => new Date(b.published_at ?? 0).getTime() - new Date(a.published_at ?? 0).getTime());
+}

--- a/src/features/admin/posts/AdminPostsPage.tsx
+++ b/src/features/admin/posts/AdminPostsPage.tsx
@@ -1,0 +1,127 @@
+import { FormEvent, useMemo, useState } from 'react';
+import { getPosts, Post, PostStatus, upsertPost } from '@/data/posts';
+
+type FormState = Pick<Post, 'title' | 'slug' | 'excerpt' | 'content' | 'cover_image' | 'author' | 'status'>;
+
+const initialForm: FormState = {
+  title: '',
+  slug: '',
+  excerpt: '',
+  content: '',
+  cover_image: '',
+  author: '',
+  status: 'draft',
+};
+
+export default function AdminPostsPage() {
+  const [posts, setPosts] = useState<Post[]>(() => getPosts());
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [form, setForm] = useState<FormState>(initialForm);
+
+  const sorted = useMemo(
+    () => [...posts].sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()),
+    [posts]
+  );
+
+  const reset = () => {
+    setEditingId(null);
+    setForm(initialForm);
+  };
+
+  const onSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const now = new Date().toISOString();
+    const previous = posts.find((p) => p.id === editingId);
+    const next: Post = {
+      id: editingId ?? crypto.randomUUID(),
+      title: form.title,
+      slug: form.slug,
+      excerpt: form.excerpt,
+      content: form.content,
+      cover_image: form.cover_image,
+      author: form.author,
+      status: form.status,
+      published_at: form.status === 'published' ? previous?.published_at ?? now : null,
+      created_at: previous?.created_at ?? now,
+      updated_at: now,
+    };
+
+    upsertPost(next);
+    setPosts(getPosts());
+    reset();
+  };
+
+  const editPost = (post: Post) => {
+    setEditingId(post.id);
+    setForm({
+      title: post.title,
+      slug: post.slug,
+      excerpt: post.excerpt,
+      content: post.content,
+      cover_image: post.cover_image,
+      author: post.author,
+      status: post.status,
+    });
+  };
+
+  return (
+    <section className="max-w-[1100px] mx-auto px-6 pt-28 pb-20 grid md:grid-cols-[1.1fr_1fr] gap-8">
+      <div>
+        <h1 className="text-4xl font-extrabold mb-2">Admin · Posts</h1>
+        <p className="text-black/60 mb-8">Erstellen, bearbeiten und veröffentlichen.</p>
+
+        <form onSubmit={onSubmit} className="space-y-4 border-2 border-black rounded-2xl p-5">
+          {(['title', 'slug', 'author', 'cover_image'] as const).map((field) => (
+            <input
+              key={field}
+              required={field !== 'cover_image'}
+              value={form[field]}
+              onChange={(e) => setForm((old) => ({ ...old, [field]: e.target.value }))}
+              placeholder={field}
+              className="w-full border-2 border-black rounded-lg px-3 py-2"
+            />
+          ))}
+          <textarea required value={form.excerpt} onChange={(e) => setForm((old) => ({ ...old, excerpt: e.target.value }))} placeholder="excerpt" className="w-full border-2 border-black rounded-lg px-3 py-2 min-h-20" />
+          <textarea required value={form.content} onChange={(e) => setForm((old) => ({ ...old, content: e.target.value }))} placeholder="content" className="w-full border-2 border-black rounded-lg px-3 py-2 min-h-40" />
+
+          <div className="flex gap-2">
+            {(['draft', 'published'] as PostStatus[]).map((status) => (
+              <button type="button" key={status} onClick={() => setForm((old) => ({ ...old, status }))} className={`px-3 py-2 rounded-lg border-2 border-black font-semibold ${form.status === status ? 'bg-brand-yellow' : 'bg-white'}`}>
+                {status === 'draft' ? 'Entwurf' : 'Veröffentlicht'}
+              </button>
+            ))}
+          </div>
+
+          <div className="flex gap-3">
+            <button type="submit" className="px-4 py-2 border-2 border-black rounded-lg font-bold bg-brand-yellow">{editingId ? 'Aktualisieren' : 'Post erstellen'}</button>
+            {editingId && <button type="button" onClick={reset} className="px-4 py-2 border-2 border-black rounded-lg">Abbrechen</button>}
+          </div>
+        </form>
+      </div>
+
+      <div className="space-y-3">
+        {sorted.map((post) => (
+          <article key={post.id} className="border-2 border-black rounded-xl p-4 bg-white">
+            <p className="text-xs uppercase text-black/60">{post.status === 'draft' ? 'Entwurf' : 'Veröffentlicht'}</p>
+            <h2 className="font-extrabold text-xl mt-1">{post.title}</h2>
+            <p className="text-sm text-black/70 mt-2">/{post.slug}</p>
+            <div className="mt-3 flex gap-2">
+              <button onClick={() => editPost(post)} className="px-3 py-1.5 border-2 border-black rounded-lg text-sm font-semibold">Bearbeiten</button>
+              {post.status !== 'published' && (
+                <button
+                  onClick={() => {
+                    upsertPost({ ...post, status: 'published', published_at: new Date().toISOString(), updated_at: new Date().toISOString() });
+                    setPosts(getPosts());
+                  }}
+                  className="px-3 py-1.5 border-2 border-black rounded-lg text-sm font-semibold bg-brand-yellow"
+                >
+                  Veröffentlichen
+                </button>
+              )}
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/features/landing/LandingPage.tsx
+++ b/src/features/landing/LandingPage.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/Button';
 import { Logo } from '@/components/ui/Logo';
 import { EventCard } from '@/features/aktionen/EventCard';
 import { events } from '@/data/events';
+import { getLatestPublishedPosts } from '@/data/posts';
 
 const fadeUp: Variants = {
   hidden: { opacity: 0, y: 30 },
@@ -17,6 +18,8 @@ const stagger: Variants = {
 };
 
 const upcomingEvents = events.filter((e) => e.registrationOpen).slice(0, 3);
+
+const latestPosts = getLatestPublishedPosts(3);
 
 const stats = [
   { value: '50+', label: 'aktive Mitglieder' },
@@ -170,6 +173,39 @@ export default function LandingPage() {
             <Button asChild variant="primary">
               <Link to="/aktionen">Alle Aktionen anzeigen <ArrowRight className="ml-2 w-4 h-4" /></Link>
             </Button>
+          </div>
+        </div>
+      </section>
+
+
+
+      {/* ── News Teaser ─────────────────────────── */}
+      <section className="py-20 px-6 bg-brand-lilac/20">
+        <div className="max-w-[1200px] mx-auto">
+          <div className="flex items-end justify-between mb-10">
+            <div>
+              <p className="text-sm font-bold text-black/50 uppercase tracking-widest mb-2">Neuigkeiten</p>
+              <h2 className="text-4xl md:text-5xl font-extrabold leading-tight">Neueste Beiträge</h2>
+            </div>
+            <Button asChild variant="ghost" className="hidden md:flex items-center gap-1.5 font-bold">
+              <Link to="/news">Alle News <ChevronRight className="w-4 h-4" /></Link>
+            </Button>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {latestPosts.map((post) => (
+              <article key={post.id} className="border-2 border-black rounded-2xl overflow-hidden bg-white shadow-[4px_4px_0_#000]">
+                {post.cover_image && <img src={post.cover_image} alt={post.title} className="w-full h-44 object-cover" />}
+                <div className="p-5">
+                  <p className="text-xs uppercase tracking-wider text-black/50 mb-2">
+                    {new Date(post.published_at ?? '').toLocaleDateString('de-DE')}
+                  </p>
+                  <h3 className="text-xl font-extrabold mb-2">{post.title}</h3>
+                  <p className="text-sm text-black/70 mb-4">{post.excerpt}</p>
+                  <Link to={`/news/${post.slug}`} className="font-bold underline">Beitrag lesen</Link>
+                </div>
+              </article>
+            ))}
           </div>
         </div>
       </section>

--- a/src/features/news/NewsDetailPage.tsx
+++ b/src/features/news/NewsDetailPage.tsx
@@ -1,0 +1,19 @@
+import { Link, Navigate, useParams } from 'react-router-dom';
+import { getPostBySlug } from '@/data/posts';
+
+export default function NewsDetailPage() {
+  const { slug = '' } = useParams();
+  const post = getPostBySlug(slug);
+
+  if (!post || post.status !== 'published') return <Navigate to="/news" replace />;
+
+  return (
+    <article className="max-w-[900px] mx-auto px-6 pt-28 pb-20">
+      <Link to="/news" className="text-sm font-bold underline">← Zurück zur News-Übersicht</Link>
+      <h1 className="text-4xl md:text-5xl font-extrabold mt-5 mb-3">{post.title}</h1>
+      <p className="text-black/60 mb-8">{new Date(post.published_at ?? '').toLocaleDateString('de-DE')} · {post.author}</p>
+      {post.cover_image && <img src={post.cover_image} alt={post.title} className="w-full h-72 object-cover rounded-2xl border-2 border-black mb-8" />}
+      <p className="text-lg leading-relaxed whitespace-pre-wrap">{post.content}</p>
+    </article>
+  );
+}

--- a/src/features/news/NewsPage.tsx
+++ b/src/features/news/NewsPage.tsx
@@ -1,0 +1,29 @@
+import { Link } from 'react-router-dom';
+import { getPublishedPosts } from '@/data/posts';
+
+export default function NewsPage() {
+  const posts = getPublishedPosts();
+
+  return (
+    <section className="max-w-[1000px] mx-auto px-6 pt-28 pb-20">
+      <h1 className="text-4xl md:text-5xl font-extrabold mb-3">News</h1>
+      <p className="text-black/60 mb-10">Aktuelles aus dem Jugendforum Grafing.</p>
+
+      <div className="grid gap-6">
+        {posts.map((post) => (
+          <article key={post.id} className="border-2 border-black rounded-2xl overflow-hidden bg-white shadow-[4px_4px_0_#000]">
+            {post.cover_image && <img src={post.cover_image} alt={post.title} className="w-full h-56 object-cover" />}
+            <div className="p-6">
+              <p className="text-xs uppercase tracking-wider text-black/50 mb-2">
+                {new Date(post.published_at ?? '').toLocaleDateString('de-DE')} · {post.author}
+              </p>
+              <h2 className="text-2xl font-extrabold mb-2">{post.title}</h2>
+              <p className="text-black/70 mb-4">{post.excerpt}</p>
+              <Link className="font-bold underline" to={`/news/${post.slug}`}>Zum Beitrag</Link>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
### Motivation
- Einführung eines redaktionellen Inhaltsmodells für „Posts“, damit Beiträge verwaltet, als Entwurf gespeichert und veröffentlicht werden können.
- Bereitstellung eines einfachen Admin-Workflows zum Erstellen/Bearbeiten/Veröffentlichen ohne Backend, um Content schnell lokal zu pflegen.
- Öffentliche News-Übersicht und Detailseiten, damit veröffentlichte Beiträge sichtbar sind und auf der Seite verlinkt werden können.

### Description
- Neues Datenmodell in `src/data/posts.ts` mit Typen `Post`/`PostStatus`, Seed-Beitrag und Helper-Funktionen `getPosts`, `upsertPost`, `getPublishedPosts`, `getLatestPublishedPosts` und `getPostBySlug`, gespeichert in `localStorage` unter dem Schlüssel `jufo_posts`.
- Admin-CRUD-Seite `src/features/admin/posts/AdminPostsPage.tsx` unter `/admin/posts` mit Formular zum Erstellen/Bearbeiten, Entwurfsstatus und Inline-Publish-Action in der Listenansicht.
- Öffentliche News-Übersicht `src/features/news/NewsPage.tsx` (`/news`) und Detailseite `src/features/news/NewsDetailPage.tsx` (`/news/:slug`) mit Redirect auf `/news`, falls Beitrag nicht existiert oder nicht veröffentlicht ist.
- Integration eines „Neueste Beiträge“ Teasers in die Landing-Page `src/features/landing/LandingPage.tsx` sowie Eintrag `News` in die Navigation und Routings in `src/App.tsx` für die neuen Seiten.

### Testing
- Versuch, die App mit `npm run build` auszuführen wurde automatisiert gestartet und schlug fehl wegen einer Umgebung/abhängigkeitsbedingten `esbuild` Plattform-Inkompatibilität (`@esbuild/darwin-arm64` installiert, benötigt `@esbuild/linux-x64`).
- Keine weiteren automatisierten Tests ausgeführt; die Änderungen sind primär UI-/client-seitig und sollten lokal in einem passenden Node-Umfeld (`npm install` auf Zielplattform) gebaut und manuell getestet.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a169e26aae483328ea8d0530c685ba9)