### PR TITLE
Add contact API endpoint with validation, persistence and UI integration

### DIFF
--- a/api/contact.ts
+++ b/api/contact.ts
@@ -1,0 +1,152 @@
+import { DatabaseSync } from 'node:sqlite';
+
+type ContactBody = {
+  name?: string;
+  email?: string;
+  subject?: string;
+  message?: string;
+  honeypot?: string;
+};
+
+type ApiRequest = {
+  method?: string;
+  headers: Record<string, string | string[] | undefined>;
+  socket?: { remoteAddress?: string };
+  body?: ContactBody;
+};
+
+type ApiResponse = {
+  status: (code: number) => ApiResponse;
+  json: (payload: unknown) => void;
+  setHeader: (name: string, value: string) => void;
+};
+
+const db = new DatabaseSync(process.env.CONTACT_DB_PATH ?? './contact.sqlite');
+
+const rateLimitStore = new Map<string, { count: number; resetAt: number }>();
+const RATE_LIMIT_MAX = Number(process.env.CONTACT_RATE_LIMIT_MAX ?? 5);
+const RATE_LIMIT_WINDOW_MS = Number(process.env.CONTACT_RATE_LIMIT_WINDOW_MS ?? 10 * 60 * 1000);
+
+function getClientIp(req: ApiRequest): string {
+  const forwardedFor = req.headers['x-forwarded-for'];
+  if (typeof forwardedFor === 'string' && forwardedFor.length > 0) {
+    return forwardedFor.split(',')[0].trim();
+  }
+  return req.socket?.remoteAddress ?? 'unknown';
+}
+
+function checkRateLimit(ip: string): boolean {
+  const now = Date.now();
+  const existing = rateLimitStore.get(ip);
+
+  if (!existing || now > existing.resetAt) {
+    rateLimitStore.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return true;
+  }
+
+  if (existing.count >= RATE_LIMIT_MAX) {
+    return false;
+  }
+
+  existing.count += 1;
+  rateLimitStore.set(ip, existing);
+  return true;
+}
+
+function isValidEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+function ensureTable(): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS contact_requests (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      name TEXT NOT NULL,
+      email TEXT NOT NULL,
+      subject TEXT NOT NULL,
+      message TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'new'
+    )
+  `);
+}
+
+async function sendNotificationEmail(payload: Required<Omit<ContactBody, 'honeypot'>>): Promise<void> {
+  const resendApiKey = process.env.RESEND_API_KEY;
+  const teamEmail = process.env.CONTACT_TEAM_EMAIL;
+
+  if (!resendApiKey || !teamEmail) {
+    return;
+  }
+
+  await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${resendApiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: process.env.CONTACT_FROM_EMAIL ?? 'Kontaktformular <onboarding@resend.dev>',
+      to: [teamEmail],
+      subject: `[Kontaktformular] ${payload.subject}`,
+      text: `Neue Kontaktanfrage\n\nName: ${payload.name}\nE-Mail: ${payload.email}\nBetreff: ${payload.subject}\n\nNachricht:\n${payload.message}`,
+    }),
+  });
+}
+
+export default async function handler(req: ApiRequest, res: ApiResponse): Promise<void> {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const ip = getClientIp(req);
+  if (!checkRateLimit(ip)) {
+    res.status(429).json({ error: 'Zu viele Anfragen. Bitte versuche es später erneut.' });
+    return;
+  }
+
+  const body = (req.body ?? {}) as ContactBody;
+  const name = body.name?.trim() ?? '';
+  const email = body.email?.trim() ?? '';
+  const subject = body.subject?.trim() ?? '';
+  const message = body.message?.trim() ?? '';
+  const honeypot = body.honeypot?.trim() ?? '';
+
+  if (honeypot.length > 0) {
+    res.status(200).json({ ok: true });
+    return;
+  }
+
+  if (!name || !email || !subject || !message) {
+    res.status(400).json({ error: 'Bitte fülle alle Pflichtfelder aus.' });
+    return;
+  }
+
+  if (!isValidEmail(email)) {
+    res.status(400).json({ error: 'Bitte gib eine gültige E-Mail-Adresse ein.' });
+    return;
+  }
+
+  if (name.length > 120 || email.length > 254 || subject.length > 200 || message.length > 5000) {
+    res.status(400).json({ error: 'Eine oder mehrere Eingaben sind zu lang.' });
+    return;
+  }
+
+  try {
+    ensureTable();
+
+    const stmt = db.prepare(
+      'INSERT INTO contact_requests (name, email, subject, message, status) VALUES (?, ?, ?, ?, ?)',
+    );
+    stmt.run(name, email, subject, message, 'new');
+
+    await sendNotificationEmail({ name, email, subject, message });
+
+    res.status(201).json({ ok: true, message: 'Nachricht erfolgreich gesendet.' });
+  } catch (error) {
+    console.error('contact api error', error);
+    res.status(500).json({ error: 'Interner Fehler beim Speichern der Anfrage.' });
+  }
+}

--- a/src/features/kontakt/KontaktPage.tsx
+++ b/src/features/kontakt/KontaktPage.tsx
@@ -28,21 +28,47 @@ const contactInfo = [
 ];
 
 export default function KontaktPage() {
-  const [form, setForm] = useState({ name: '', email: '', betreff: '', nachricht: '' });
+  const [form, setForm] = useState({ name: '', email: '', betreff: '', nachricht: '', honeypot: '' });
   const [submitted, setSubmitted] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     setForm((f) => ({ ...f, [e.target.name]: e.target.value }));
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
-    setTimeout(() => {
-      setLoading(false);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/contact', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          name: form.name,
+          email: form.email,
+          subject: form.betreff,
+          message: form.nachricht,
+          honeypot: form.honeypot,
+        }),
+      });
+
+      const data = (await response.json()) as { error?: string };
+
+      if (!response.ok) {
+        throw new Error(data.error ?? 'Nachricht konnte nicht gesendet werden.');
+      }
+
       setSubmitted(true);
-    }, 900);
+    } catch (submitError) {
+      setError(submitError instanceof Error ? submitError.message : 'Unbekannter Fehler beim Senden.');
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -122,6 +148,16 @@ export default function KontaktPage() {
               <div className="bg-white rounded-[2rem] border-2 border-black shadow-[6px_6px_0_#000] p-8">
                 <h2 className="text-2xl font-extrabold mb-6">Nachricht senden</h2>
                 <form onSubmit={handleSubmit} className="space-y-5">
+                  <input
+                    type="text"
+                    name="honeypot"
+                    tabIndex={-1}
+                    autoComplete="off"
+                    value={form.honeypot}
+                    onChange={handleChange}
+                    className="hidden"
+                    aria-hidden="true"
+                  />
                   <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div>
                       <label className="block text-xs font-bold mb-1.5 uppercase tracking-wider">
@@ -183,6 +219,12 @@ export default function KontaktPage() {
                     />
                   </div>
 
+                  {error ? (
+                    <div className="rounded-xl border-2 border-red-400 bg-red-50 px-4 py-3 text-sm text-red-700">
+                      {error}
+                    </div>
+                  ) : null}
+
                   <Button
                     type="submit"
                     variant="accent"
@@ -220,7 +262,8 @@ export default function KontaktPage() {
                   variant="primary"
                   onClick={() => {
                     setSubmitted(false);
-                    setForm({ name: '', email: '', betreff: '', nachricht: '' });
+                    setError(null);
+                    setForm({ name: '', email: '', betreff: '', nachricht: '', honeypot: '' });
                   }}
                 >
                   Neue Nachricht


### PR DESCRIPTION
### Motivation
- Provide a real backend for contact submissions instead of a client-side `setTimeout`, with persistence and basic anti-spam/rate-limit protections.
- Ensure form errors are surfaced to users and allow retrying failed submissions.

### Description
- Added a serverless endpoint `api/contact.ts` that accepts `POST` requests and validates required fields (`name`, `email`, `subject`, `message`), email format, and max length limits, and rejects requests with a filled `honeypot` field.
- Implemented simple IP-based in-memory rate limiting and automatic creation/persistence of a `contact_requests` SQLite table with fields `id`, `created_at`, `name`, `email`, `subject`, `message`, `status`.
- Added optional team notification via Resend when `RESEND_API_KEY` and `CONTACT_TEAM_EMAIL` are set.
- Updated `src/features/kontakt/KontaktPage.tsx` to add a hidden `honeypot` input, submit form data with `fetch('/api/contact')`, show loading state, display inline API errors with retry via re-submission, and keep the existing clear success/reset flow.
- Implementation notes: the endpoint uses `node:sqlite` `DatabaseSync` and defaults to `./contact.sqlite` (override via `CONTACT_DB_PATH`), and the rate limiter is process-memory-based (resets on cold starts).

### Testing
- `npx tsc -b` completed successfully (TypeScript build/check passed).
- `npm run build` failed in this environment due to an existing `esbuild` platform mismatch in `node_modules` (platform binary `@esbuild/darwin-arm64` vs expected `@esbuild/linux-x64`), which is an environment/dependency issue and not caused by these code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a169e17a39c8332baa7d0408499d9d4)