### PR TITLE
API-Endpoint `/api/applications` mit Validation, Persistenz und echtem Submit

### DIFF
--- a/api/applications.ts
+++ b/api/applications.ts
@@ -1,0 +1,54 @@
+import { isApplicationStatus } from '../src/types/application';
+import { createApplication, listApplications, validateApplicationPayload } from '../src/server/applications';
+
+type ApiRequest = {
+  method?: string;
+  body?: unknown;
+  query?: Record<string, string | string[] | undefined>;
+  headers: Record<string, string | string[] | undefined>;
+  socket?: { remoteAddress?: string };
+};
+
+type ApiResponse = {
+  status: (statusCode: number) => ApiResponse;
+  json: (payload: unknown) => void;
+  setHeader: (name: string, value: string) => void;
+};
+
+const getIpAddress = (req: ApiRequest) => {
+  const forwarded = req.headers['x-forwarded-for'];
+  if (Array.isArray(forwarded)) return forwarded[0];
+  if (typeof forwarded === 'string') return forwarded.split(',')[0]?.trim() ?? '';
+  return req.socket?.remoteAddress ?? '';
+};
+
+export default async function handler(req: ApiRequest, res: ApiResponse) {
+  if (req.method === 'POST') {
+    const validation = validateApplicationPayload(req.body);
+
+    if (!validation.success) {
+      return res.status(400).json({ message: 'Validierung fehlgeschlagen.', errors: validation.errors });
+    }
+
+    const created = await createApplication(validation.data, getIpAddress(req));
+    return res.status(201).json({ message: 'Bewerbung erfolgreich gespeichert.', id: created.id });
+  }
+
+  if (req.method === 'GET') {
+    const statusRaw = req.query?.status;
+    const statusParam = typeof statusRaw === 'string' ? statusRaw : undefined;
+
+    if (statusParam && !isApplicationStatus(statusParam)) {
+      return res.status(400).json({
+        message: 'Ungültiger Status-Filter.',
+        allowed: ['new', 'in_review', 'accepted', 'rejected'],
+      });
+    }
+
+    const applications = await listApplications(statusParam);
+    return res.status(200).json({ applications, count: applications.length, filter: { status: statusParam ?? null } });
+  }
+
+  res.setHeader('Allow', 'GET, POST');
+  return res.status(405).json({ message: 'Methode nicht erlaubt.' });
+}

--- a/src/features/mitmachen/MitmachenPage.tsx
+++ b/src/features/mitmachen/MitmachenPage.tsx
@@ -32,6 +32,7 @@ export default function MitmachenPage() {
   });
   const [submitted, setSubmitted] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
@@ -43,13 +44,33 @@ export default function MitmachenPage() {
     }));
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setErrorMessage(null);
     setLoading(true);
-    setTimeout(() => {
-      setLoading(false);
+
+    try {
+      const response = await fetch('/api/applications', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(form),
+      });
+
+      const result = (await response.json()) as { message?: string; errors?: string[] };
+
+      if (!response.ok) {
+        const message = result.errors?.join(' ') || result.message || 'Bewerbung konnte nicht gesendet werden.';
+        throw new Error(message);
+      }
+
       setSubmitted(true);
-    }, 1000);
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : 'Unbekannter Fehler beim Senden der Bewerbung.');
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -247,6 +268,13 @@ export default function MitmachenPage() {
                       Die Daten werden nicht an Dritte weitergegeben. *
                     </label>
                   </div>
+
+
+                  {errorMessage ? (
+                    <div className="rounded-xl border-2 border-red-500 bg-red-50 px-4 py-3 text-sm font-medium text-red-700">
+                      {errorMessage}
+                    </div>
+                  ) : null}
 
                   <Button
                     type="submit"

--- a/src/server/applications.ts
+++ b/src/server/applications.ts
@@ -1,0 +1,103 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import type { ApplicationInput, ApplicationRecord, ApplicationStatus } from '../types/application';
+
+const APPLICATION_FILE = path.join(process.cwd(), '.data', 'applications.json');
+
+type ValidationResult =
+  | { success: true; data: ApplicationInput }
+  | { success: false; errors: string[] };
+
+const isNonEmptyString = (value: unknown, min = 1, max = 2000): value is string =>
+  typeof value === 'string' && value.trim().length >= min && value.trim().length <= max;
+
+export const validateApplicationPayload = (payload: unknown): ValidationResult => {
+  const errors: string[] = [];
+
+  if (typeof payload !== 'object' || payload === null) {
+    return { success: false, errors: ['Ungültiger Request-Body.'] };
+  }
+
+  const data = payload as Record<string, unknown>;
+
+  if (!isNonEmptyString(data.vorname, 2, 80)) errors.push('Vorname muss zwischen 2 und 80 Zeichen lang sein.');
+  if (!isNonEmptyString(data.nachname, 2, 80)) errors.push('Nachname muss zwischen 2 und 80 Zeichen lang sein.');
+
+  const email = typeof data.email === 'string' ? data.email.trim() : '';
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) || email.length > 255) {
+    errors.push('E-Mail-Adresse ist ungültig.');
+  }
+
+  const alter = typeof data.alter === 'string' ? Number.parseInt(data.alter, 10) : Number.NaN;
+  if (Number.isNaN(alter) || alter < 13 || alter > 25) {
+    errors.push('Alter muss zwischen 13 und 25 liegen.');
+  }
+
+  if (!isNonEmptyString(data.wohnort, 2, 120)) errors.push('Wohnort muss zwischen 2 und 120 Zeichen lang sein.');
+  if (!isNonEmptyString(data.motivation, 20, 4000)) errors.push('Motivation muss mindestens 20 Zeichen enthalten.');
+  if (data.consent !== true) errors.push('Datenschutzeinwilligung ist erforderlich.');
+
+  if (errors.length > 0) return { success: false, errors };
+
+  return {
+    success: true,
+    data: {
+      vorname: (data.vorname as string).trim(),
+      nachname: (data.nachname as string).trim(),
+      email,
+      alter: String(alter),
+      wohnort: (data.wohnort as string).trim(),
+      motivation: (data.motivation as string).trim(),
+      consent: true,
+    },
+  };
+};
+
+const ensureDataDir = async () => {
+  await fs.mkdir(path.dirname(APPLICATION_FILE), { recursive: true });
+};
+
+const readApplications = async (): Promise<ApplicationRecord[]> => {
+  try {
+    const raw = await fs.readFile(APPLICATION_FILE, 'utf-8');
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed) ? (parsed as ApplicationRecord[]) : [];
+  } catch {
+    return [];
+  }
+};
+
+const writeApplications = async (applications: ApplicationRecord[]) => {
+  await ensureDataDir();
+  await fs.writeFile(APPLICATION_FILE, JSON.stringify(applications, null, 2), 'utf-8');
+};
+
+export const createApplication = async (
+  input: ApplicationInput,
+  ipAddress: string,
+  status: ApplicationStatus = 'new'
+): Promise<ApplicationRecord> => {
+  const nowIso = new Date().toISOString();
+  const ip_hash = createHash('sha256').update(ipAddress || 'unknown').digest('hex');
+
+  const record: ApplicationRecord = {
+    id: randomUUID(),
+    created_at: nowIso,
+    consent_timestamp: nowIso,
+    ip_hash,
+    status,
+    ...input,
+  };
+
+  const applications = await readApplications();
+  applications.push(record);
+  await writeApplications(applications);
+
+  return record;
+};
+
+export const listApplications = async (status?: ApplicationStatus): Promise<ApplicationRecord[]> => {
+  const applications = await readApplications();
+  return status ? applications.filter((application) => application.status === status) : applications;
+};

--- a/src/types/application.ts
+++ b/src/types/application.ts
@@ -1,0 +1,24 @@
+export const applicationStatuses = ['new', 'in_review', 'accepted', 'rejected'] as const;
+
+export type ApplicationStatus = (typeof applicationStatuses)[number];
+
+export type ApplicationInput = {
+  vorname: string;
+  nachname: string;
+  email: string;
+  alter: string;
+  wohnort: string;
+  motivation: string;
+  consent: boolean;
+};
+
+export type ApplicationRecord = ApplicationInput & {
+  id: string;
+  created_at: string;
+  consent_timestamp: string;
+  ip_hash: string;
+  status: ApplicationStatus;
+};
+
+export const isApplicationStatus = (value: unknown): value is ApplicationStatus =>
+  typeof value === 'string' && applicationStatuses.includes(value as ApplicationStatus);

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,6 @@
 {
-  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+  "rewrites": [
+    { "source": "/api/(.*)", "destination": "/api/$1" },
+    { "source": "/(.*)", "destination": "/" }
+  ]
 }


### PR DESCRIPTION
### Motivation
- Bereitstellen eines echten Backend-Endpunkts zum Empfangen von Bewerbungen anstelle des bisherigen Fake-Submits.  
- Serverseitige Validierung aller Felder aus `FormState` zur Vermeidung ungültiger oder unvollständiger Einträge.  
- Daten persistent speichern und datenschutzrelevante Metadaten (`consent_timestamp`, `ip_hash`) protokollieren.  
- Admin-Workflow vorbereiten durch standardisierte Statuswerte und Filterbarkeit.

### Description
- Neuer Type- und Status-Definitionen in `src/types/application.ts` mit Statuswerten `new`, `in_review`, `accepted`, `rejected` und Hilfsfunktion `isApplicationStatus`.  
- Serverseitige Logik in `src/server/applications.ts` implementiert: Validierung (`validateApplicationPayload`), Erzeugung (`createApplication`) und Abfrage (`listApplications`) von Application-Records; Speicherung in `.data/applications.json`; Erzeugung von `consent_timestamp`, `ip_hash` und `id`.  
- Neue API-Route `api/applications.ts` bereitgestellt, die `POST` zum Anlegen und `GET` mit optionalem `?status=`-Filter unterstützt und ungültige Status-Filter zurückweist.  
- Frontend `src/features/mitmachen/MitmachenPage.tsx` angepasst: der Timeout-Fake wurde durch einen echten `fetch('/api/applications')` ersetzt; `loading`, `errorMessage` und `submitted` Handling sowie eine Fehleranzeige im Formular wurden hinzugefügt.  
- `vercel.json` angepasst, um `/api/*`-Routen explizit zu behandeln.

### Testing
- Build-Versuch mit `npm run build` wurde ausgeführt und schlug fehl aufgrund eines Plattform-Mismatches der vorinstallierten `esbuild`-Binärdatei (`@esbuild/darwin-arm64` statt `@esbuild/linux-x64`).  
- Versuch, `@vercel/node` zu installieren (`npm install -D @vercel/node`) schlug fehl mit einem `403` vom Registry-Server; dadurch konnte die Vercel-spezifische Integration im Container nicht komplett validiert.
- Es wurden keine weiteren automatisierten Tests ausgeführt; die Änderungen wurden lokal committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a169e200e0483328073466fecd1989a)