### PR TITLE
Store contact and applications in Postgres

### DIFF
--- a/api/applications.ts
+++ b/api/applications.ts
@@ -1,5 +1,8 @@
 import { isApplicationStatus } from '../src/types/application';
-import { createApplication, listApplications, validateApplicationPayload } from '../src/server/applications';
+import { createHash, randomUUID } from 'node:crypto';
+import { getPool } from './db.js';
+import { validateApplicationPayload } from '../src/server/applications';
+import type { ApplicationInput, ApplicationStatus } from '../src/types/application';
 
 type ApiRequest = {
   method?: string;
@@ -20,6 +23,72 @@ const getIpAddress = (req: ApiRequest) => {
   if (Array.isArray(forwarded)) return forwarded[0];
   if (typeof forwarded === 'string') return forwarded.split(',')[0]?.trim() ?? '';
   return req.socket?.remoteAddress ?? '';
+};
+
+const ensureApplicationsTable = async () => {
+  await getPool().query(`
+    CREATE TABLE IF NOT EXISTS applications (
+      id UUID PRIMARY KEY,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      consent_timestamp TIMESTAMPTZ NOT NULL,
+      ip_hash TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'new',
+      vorname TEXT NOT NULL,
+      nachname TEXT NOT NULL,
+      email TEXT NOT NULL,
+      alter TEXT NOT NULL,
+      wohnort TEXT NOT NULL,
+      motivation TEXT NOT NULL,
+      consent BOOLEAN NOT NULL DEFAULT TRUE
+    )
+  `);
+};
+
+const createApplication = async (input: ApplicationInput, ipAddress: string, status: ApplicationStatus = 'new') => {
+  await ensureApplicationsTable();
+
+  const id = randomUUID();
+  const nowIso = new Date().toISOString();
+  const ipHash = createHash('sha256').update(ipAddress || 'unknown').digest('hex');
+
+  await getPool().query(
+    `INSERT INTO applications (
+       id, created_at, consent_timestamp, ip_hash, status,
+       vorname, nachname, email, alter, wohnort, motivation, consent
+     )
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+    [
+      id,
+      nowIso,
+      nowIso,
+      ipHash,
+      status,
+      input.vorname,
+      input.nachname,
+      input.email,
+      input.alter,
+      input.wohnort,
+      input.motivation,
+      input.consent,
+    ],
+  );
+
+  return { id };
+};
+
+const listApplications = async (status?: ApplicationStatus) => {
+  await ensureApplicationsTable();
+
+  const result = await getPool().query(
+    `SELECT id, created_at, consent_timestamp, ip_hash, status,
+            vorname, nachname, email, alter, wohnort, motivation, consent
+       FROM applications
+      WHERE ($1::text IS NULL OR status = $1)
+      ORDER BY created_at DESC`,
+    [status ?? null],
+  );
+
+  return result.rows;
 };
 
 export default async function handler(req: ApiRequest, res: ApiResponse) {

--- a/api/contact.ts
+++ b/api/contact.ts
@@ -1,4 +1,4 @@
-import { DatabaseSync } from 'node:sqlite';
+import { getPool } from './db.js';
 
 type ContactBody = {
   name?: string;
@@ -20,8 +20,6 @@ type ApiResponse = {
   json: (payload: unknown) => void;
   setHeader: (name: string, value: string) => void;
 };
-
-const db = new DatabaseSync(process.env.CONTACT_DB_PATH ?? './contact.sqlite');
 
 const rateLimitStore = new Map<string, { count: number; resetAt: number }>();
 const RATE_LIMIT_MAX = Number(process.env.CONTACT_RATE_LIMIT_MAX ?? 5);
@@ -57,11 +55,11 @@ function isValidEmail(email: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 }
 
-function ensureTable(): void {
-  db.exec(`
+async function ensureTable(): Promise<void> {
+  await getPool().query(`
     CREATE TABLE IF NOT EXISTS contact_requests (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      id BIGSERIAL PRIMARY KEY,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       name TEXT NOT NULL,
       email TEXT NOT NULL,
       subject TEXT NOT NULL,
@@ -135,12 +133,12 @@ export default async function handler(req: ApiRequest, res: ApiResponse): Promis
   }
 
   try {
-    ensureTable();
+    await ensureTable();
 
-    const stmt = db.prepare(
-      'INSERT INTO contact_requests (name, email, subject, message, status) VALUES (?, ?, ?, ?, ?)',
+    await getPool().query(
+      'INSERT INTO contact_requests (name, email, subject, message, status) VALUES ($1, $2, $3, $4, $5)',
+      [name, email, subject, message, 'new'],
     );
-    stmt.run(name, email, subject, message, 'new');
 
     await sendNotificationEmail({ name, email, subject, message });
 

--- a/db/migrations/002_contact_requests.sql
+++ b/db/migrations/002_contact_requests.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS contact_requests (
+  id BIGSERIAL PRIMARY KEY,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  name TEXT NOT NULL,
+  email TEXT NOT NULL,
+  subject TEXT NOT NULL,
+  message TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'new'
+);
+
+CREATE INDEX IF NOT EXISTS idx_contact_requests_created_at
+  ON contact_requests(created_at DESC);

--- a/db/migrations/003_applications.sql
+++ b/db/migrations/003_applications.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS applications (
+  id UUID PRIMARY KEY,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  consent_timestamp TIMESTAMPTZ NOT NULL,
+  ip_hash TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'new',
+  vorname TEXT NOT NULL,
+  nachname TEXT NOT NULL,
+  email TEXT NOT NULL,
+  alter TEXT NOT NULL,
+  wohnort TEXT NOT NULL,
+  motivation TEXT NOT NULL,
+  consent BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+CREATE INDEX IF NOT EXISTS idx_applications_status_created_at
+  ON applications(status, created_at DESC);


### PR DESCRIPTION
### Summary
- Move contact request storage from local SQLite to the shared Postgres pool.
- Store applications directly in Postgres from the Vercel API route.
- Add migrations for `contact_requests` and `applications` tables.

### Testing
- `npm ci`
- `npm run build`